### PR TITLE
feat: implement room deletion logic when last viewer leaves; refactor…

### DIFF
--- a/src/routes/api/room/leave.$userid.ts
+++ b/src/routes/api/room/leave.$userid.ts
@@ -5,14 +5,7 @@ import { removeViewerFromRoom } from "~/lib/server/functions";
 export const APIRoute = createAPIFileRoute("/api/room/leave/$userid")({
   GET: async ({ params }) => {
     const { userid } = params;
-    const leaveData = await removeViewerFromRoom({ data: userid });
-    console.log("leaveData", leaveData);
-    return json({ status: "success" });
-  },
-  POST: async ({ params }) => {
-    const { userid } = params;
-    const leaveData = await removeViewerFromRoom({ data: userid });
-    console.log("leaveData", leaveData);
+    await removeViewerFromRoom({ data: userid });
     return json({ status: "success" });
   },
 });


### PR DESCRIPTION
This pull request introduces enhancements to room management logic, including handling empty rooms and updating the streamer when necessary. It also simplifies the API route for removing a viewer from a room. Below are the key changes:

### Enhancements to Room Management Logic

* Added logic to delete a room if it becomes empty. A check is performed after 5 minutes to confirm the room is still empty before deletion. (`src/lib/server/functions.ts`, [src/lib/server/functions.tsR132-R183](diffhunk://#diff-25314947e12a28c609847b571ed248ef80283b1635c75661d84d3017ec749b61R132-R183))
* Introduced the `isRoomEmpty` helper function to determine whether a room has no users. (`src/lib/server/functions.ts`, [src/lib/server/functions.tsR132-R183](diffhunk://#diff-25314947e12a28c609847b571ed248ef80283b1635c75661d84d3017ec749b61R132-R183))
* Added the `updateRoomStreamer` function to assign a new streamer when the current streamer leaves the room. The first remaining viewer is promoted to streamer. (`src/lib/server/functions.ts`, [src/lib/server/functions.tsR208-R228](diffhunk://#diff-25314947e12a28c609847b571ed248ef80283b1635c75661d84d3017ec749b61R208-R228))

### Simplification of API Route

* Removed redundant `POST` handler and streamlined the `GET` handler in the `leave.$userid.ts` API route. The `removeViewerFromRoom` function is now called directly, and unnecessary logging was removed. (`src/routes/api/room/leave.$userid.ts`, [src/routes/api/room/leave.$userid.tsL8-R8](diffhunk://#diff-d3a3ebfc1fbda6c11716dbd414155afab1e09fca09cf15a89c7633ae1656d696L8-R8))… leave user API route for cleaner handling