### PR TITLE
feat: add ChatMessageDisplay component and integrate chat message han…

### DIFF
--- a/src/lib/components/ChatMessageDisplay.tsx
+++ b/src/lib/components/ChatMessageDisplay.tsx
@@ -1,0 +1,45 @@
+import TimeAgo from "javascript-time-ago";
+import en from "javascript-time-ago/locale/en";
+import type { ChatMessage } from "../types";
+
+TimeAgo.addDefaultLocale(en);
+
+// Create formatter (English).
+const timeAgo = new TimeAgo("en-US");
+
+export default function ChatMessageDisplay({ message }: { message: ChatMessage }) {
+  console.log("MessageContent", message);
+  return (
+    <div className="flex items-center gap-1 p-1">
+      {message.user?.image && (
+        <img
+          src={message.user?.image || "/default-avatar.png"}
+          alt={message.user?.name || "User"}
+          className="w-8 h-8 rounded-full"
+          loading="lazy"
+        />
+      )}
+      <div className="flex flex-col">
+        {message.user && (
+          <>
+            <div className="flex items-center gap-2">
+              <span className="font-bold">{message.user?.name || "Unknown User"}</span>
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                {timeAgo.format(new Date(message.timestamp))}
+              </span>
+            </div>
+
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              {message.content}
+            </div>
+          </>
+        )}
+        {!message.user && (
+          <div className="text-sm text-gray-700 dark:text-gray-300 font-semibold">
+            {message.content}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/routes/room.$roomid.tsx
+++ b/src/routes/room.$roomid.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import ReactPlayer from "react-player";
 import useWebSocket, { ReadyState } from "react-use-websocket";
+import ChatMessageDisplay from "~/lib/components/ChatMessageDisplay";
 import ViewerDisplay from "~/lib/components/ViewerDisplay";
 import { createRoom, getServerURL, getUserById, roomById } from "~/lib/server/functions";
 import { MessageType, type ChatMessage } from "~/lib/types";
@@ -259,13 +260,31 @@ function RouteComponent() {
             <div className="text-sm text-gray-500 dark:text-gray-400">
               {chatMessages.length > 0 &&
                 chatMessages.map((message) => (
-                  <div key={message.id}>{message.content}</div>
+                  <ChatMessageDisplay message={message} key={message.id} />
                 ))}
             </div>
           </div>
           <input
             type="text"
             placeholder="Type a message..."
+            disabled={readyState !== ReadyState.OPEN}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                const input = e.target as HTMLInputElement;
+                const message = input.value;
+                if (message.trim() !== "") {
+                  sendMessage(
+                    JSON.stringify({
+                      type: MessageType.CHATMESSAGE,
+                      content: message,
+                      user: liveUserData,
+                      roomID: liveRoomData?.id,
+                    }),
+                  );
+                  input.value = "";
+                }
+              }
+            }}
             className="border bg-gray-100 dark:bg-gray-700 w-full p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -105,4 +105,16 @@ const leaveRoom = async (peer: Peer, user: User, roomId: string) => {
 
 const chatMessage = (peer: Peer, roomID: string, user: User, content: string) => {
   console.log("message", roomID, user, content);
+
+  const msgContent = {
+    type: MessageType.CHATMESSAGE,
+    id: uuidv4(),
+    content,
+    user,
+    timestamp: new Date(),
+  };
+  peer.publish(roomID, JSON.stringify(msgContent));
+
+  // Broadcast to sender
+  peer.send(JSON.stringify(msgContent));
 };


### PR DESCRIPTION
This pull request introduces a new `ChatMessageDisplay` component to enhance the display of chat messages and integrates it into the chat system. It also adds functionality for sending and broadcasting chat messages with timestamps. Below are the most important changes grouped by theme:

### Chat Message Display Enhancements:
* Added a new `ChatMessageDisplay` component in `src/lib/components/ChatMessageDisplay.tsx` to format and display chat messages with user information, timestamps (using `javascript-time-ago`), and fallback handling for missing user data.
* Updated the chat message rendering in `src/routes/room.$roomid.tsx` to use the new `ChatMessageDisplay` component instead of directly rendering message content.

### Message Sending and Broadcasting:
* Enhanced the `chatMessage` function in `src/ws.ts` to include a unique message ID, user information, and a timestamp. The message is now broadcast to the room and sent back to the sender.
* Updated the chat input field in `src/routes/room.$roomid.tsx` to send a message when the Enter key is pressed, including user and room details, and to disable input when the WebSocket connection is not open.

### Integration:
* Imported the new `ChatMessageDisplay` component into `src/routes/room.$roomid.tsx` for integration with the chat system.…dling in room