### PR TITLE
feat: mobile responsiveness, profile stats, and misc fixes

### DIFF
--- a/docs/superpowers/specs/2026-03-30-profile-stats-design.md
+++ b/docs/superpowers/specs/2026-03-30-profile-stats-design.md
@@ -1,0 +1,81 @@
+# Profile Stats Card — Design Spec
+
+**Date:** 2026-03-30
+
+## Problem
+
+The profile page currently shows only the user's name, avatar, and top connections. There is no summary of the user's activity on the platform, making profiles feel sparse and uninformative.
+
+## Goal
+
+Add two new sections to the profile page (visible to all visitors):
+
+1. **Stats card** — Member Since, Total Watch Time, Watch Time (Last 30d)
+2. **Top Connections (Last 30d) card** — separate from the existing all-time connections card, showing who the user has shared room time with in the past 30 days
+
+---
+
+## Architecture
+
+### Data Layer
+
+**`src/db/queries/stats.ts` — `getUserStats()`**
+Extend to also compute `watchTimeLast30Days`. Add one query: sum `roomParticipants.totalTimeSeconds` where `userId = userId AND joinedAt >= 30 days ago`. The `thirtyDaysAgo` variable already exists in the function — reuse it. Update the `UserStats` interface to include `watchTimeLast30Days: number`.
+
+**`src/db/queries.ts` — new `getTopRelationshipsLast30Days()`**
+Query the `userRoomOverlaps` table (which has per-session `overlapStart` timestamps) filtered to the last 30 days. Group by the other user, summing `overlapSeconds` and counting distinct rooms. Join with `users` for name/image. Returns `RelationshipWithUser[]` — same shape as the existing `getTopRelationships()`.
+
+**`src/db/queries.ts` — `UserProfileData` type**
+Add:
+- `stats: { totalWatchTime: number; watchTimeLast30Days: number }`
+- `topRelationshipsLast30Days: RelationshipWithUser[]`
+
+The `user.createdAt` is already returned, so no change needed there.
+
+**`src/utils/profile.ts` — `getProfileData()`**
+Call `getUserStats()` and `getTopRelationshipsLast30Days()` in parallel with the existing `getTopRelationships()` call. Include both in the return object.
+
+### UI Layer
+
+**`src/routes/profile.$userId.tsx`**
+
+Card order (top to bottom):
+1. Profile header (existing)
+2. **Stats card** (new)
+3. Top Connections — All Time (existing, renamed heading for clarity)
+4. **Top Connections — Last 30 Days** (new card, same layout as all-time)
+
+**Stats card** — three equal-width columns:
+
+| Member Since | Total Watch Time | Last 30 Days |
+|---|---|---|
+| Jan 2025 | 142h 30m | 12h 5m |
+
+- Label: `text-text-tertiary text-sm`
+- Value: `text-text-primary text-2xl font-bold mt-1`
+- Card: `bg-depth-1 rounded-lg p-6 border border-border-subtle`
+- Date formatted as `MMM YYYY` via `toLocaleDateString("en-US", { month: "short", year: "numeric" })`
+- Time via existing `formatDuration()`
+
+**Top Connections (Last 30 Days) card** — identical layout to all-time card, with empty state: *"No shared room time in the last 30 days."* (or own-profile variant: *"You haven't shared room time with anyone in the last 30 days."*)
+
+---
+
+## Files to Modify
+
+1. `src/db/queries/stats.ts` — extend `UserStats` + add 30d watch time query
+2. `src/db/queries.ts` — add `getTopRelationshipsLast30Days()` + update `UserProfileData` type
+3. `src/utils/profile.ts` — call new functions, include in return
+4. `src/routes/profile.$userId.tsx` — render stats card + 30d connections card
+
+---
+
+## Verification
+
+1. Visit any profile — stats card and 30d connections card both appear
+2. Stats visible when logged out (public)
+3. `Member Since` shows correct month/year
+4. Watch time values format correctly via `formatDuration()`
+5. 30d connections card shows correct users (only those from last 30 days)
+6. Empty states render correctly when no recent activity
+7. Run `pnpm check` — no lint/format errors

--- a/drizzle/0003_spicy_northstar.sql
+++ b/drizzle/0003_spicy_northstar.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "community_stats_snapshots" ALTER COLUMN "total_watch_seconds_this_week" SET DATA TYPE numeric(10, 2);--> statement-breakpoint
+ALTER TABLE "community_stats_snapshots" ALTER COLUMN "total_watch_seconds_this_week" SET DEFAULT '0';

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,844 @@
+{
+  "id": "d167d1ce-b771-4b0d-941b-dfcfd2eb9c49",
+  "prevId": "fdeae386-aeda-4b0a-bcb0-3a2b920f6432",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_stats_snapshots": {
+      "name": "community_stats_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_registered_users": {
+          "name": "total_registered_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_watch_hours_this_week": {
+          "name": "total_watch_hours_this_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_watch_seconds_this_week": {
+          "name": "total_watch_seconds_this_week",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "most_active_streamers": {
+          "name": "most_active_streamers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_users_this_week": {
+          "name": "new_users_this_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_stats_calculated_at_idx": {
+          "name": "community_stats_calculated_at_idx",
+          "columns": [
+            {
+              "expression": "calculated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.room_participants": {
+      "name": "room_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_time_seconds": {
+          "name": "total_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "room_participants_room_idx": {
+          "name": "room_participants_room_idx",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "room_participants_user_idx": {
+          "name": "room_participants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "room_participants_room_id_streaming_rooms_id_fk": {
+          "name": "room_participants_room_id_streaming_rooms_id_fk",
+          "tableFrom": "room_participants",
+          "tableTo": "streaming_rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "room_participants_user_id_users_id_fk": {
+          "name": "room_participants_user_id_users_id_fk",
+          "tableFrom": "room_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streaming_rooms": {
+      "name": "streaming_rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamer_id": {
+          "name": "streamer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streaming_rooms_streamer_id_users_id_fk": {
+          "name": "streaming_rooms_streamer_id_users_id_fk",
+          "tableFrom": "streaming_rooms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "streamer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_relationships": {
+      "name": "user_relationships",
+      "schema": "",
+      "columns": {
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_time_seconds": {
+          "name": "total_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rooms_count": {
+          "name": "rooms_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_interaction_at": {
+          "name": "last_interaction_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_relationships_user1_idx": {
+          "name": "user_relationships_user1_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_relationships_user2_idx": {
+          "name": "user_relationships_user2_idx",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_relationships_time_idx": {
+          "name": "user_relationships_time_idx",
+          "columns": [
+            {
+              "expression": "total_time_seconds",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_relationships_user1_id_users_id_fk": {
+          "name": "user_relationships_user1_id_users_id_fk",
+          "tableFrom": "user_relationships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_relationships_user2_id_users_id_fk": {
+          "name": "user_relationships_user2_id_users_id_fk",
+          "tableFrom": "user_relationships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_relationships_user1_id_user2_id_pk": {
+          "name": "user_relationships_user1_id_user2_id_pk",
+          "columns": [
+            "user1_id",
+            "user2_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_room_overlaps": {
+      "name": "user_room_overlaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap_start": {
+          "name": "overlap_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap_end": {
+          "name": "overlap_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap_seconds": {
+          "name": "overlap_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_room_overlaps_room_idx": {
+          "name": "user_room_overlaps_room_idx",
+          "columns": [
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_room_overlaps_pair_idx": {
+          "name": "user_room_overlaps_pair_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_room_overlaps_room_id_streaming_rooms_id_fk": {
+          "name": "user_room_overlaps_room_id_streaming_rooms_id_fk",
+          "tableFrom": "user_room_overlaps",
+          "tableTo": "streaming_rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_room_overlaps_user1_id_users_id_fk": {
+          "name": "user_room_overlaps_user1_id_users_id_fk",
+          "tableFrom": "user_room_overlaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_room_overlaps_user2_id_users_id_fk": {
+          "name": "user_room_overlaps_user2_id_users_id_fk",
+          "tableFrom": "user_room_overlaps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1773670743483,
       "tag": "0002_normal_vivisector",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1774860043595,
+      "tag": "0003_spicy_northstar",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/CommunityStatsCard.tsx
+++ b/src/components/CommunityStatsCard.tsx
@@ -78,7 +78,7 @@ export function CommunityStatsCard({
 					</div>
 					<div className="flex items-center justify-between p-2.5 rounded-lg bg-depth-2">
 						<span className="text-sm text-text-secondary">
-							Active Streamers
+							Active Streamers (30d)
 						</span>
 						<span className="text-lg font-bold text-accent">
 							{stats.mostActiveStreamers}

--- a/src/components/RoomList.tsx
+++ b/src/components/RoomList.tsx
@@ -65,6 +65,7 @@ interface RoomListProps {
 			description: string | null;
 			status: string;
 			createdAt: Date;
+			endedAt: Date | null;
 		};
 		streamer: {
 			id: string;
@@ -72,6 +73,7 @@ interface RoomListProps {
 			image: string | null;
 		} | null;
 		participantCount: number;
+		streamerIsPresent: boolean;
 		participants?: Participant[];
 	}>;
 	userId?: string;
@@ -112,23 +114,7 @@ export function RoomList({ initialRooms, userId }: RoomListProps) {
 
 	// Transform database rooms to component format
 	const rooms: Room[] = useMemo(() => {
-		const sourceData = (searchedRooms || initialRooms) as Array<{
-			room: {
-				id: string;
-				name: string;
-				description: string | null;
-				status: string;
-				createdAt: Date;
-				endedAt: Date | null;
-			};
-			streamer: {
-				id: string;
-				name: string;
-				image: string | null;
-			} | null;
-			participantCount: number;
-			participants?: Participant[];
-		}>;
+		const sourceData = searchedRooms || initialRooms;
 		if (!sourceData) return [];
 
 		return sourceData.map((roomData) => ({
@@ -138,7 +124,7 @@ export function RoomList({ initialRooms, userId }: RoomListProps) {
 			streamerName: roomData.streamer?.name,
 			streamerImage: roomData.streamer?.image || undefined,
 			participantCount: roomData.participantCount || 0,
-			maxUsersJoined: undefined,
+			streamerIsPresent: roomData.streamerIsPresent,
 			status: roomData.room.status as
 				| "waiting"
 				| "preparing"

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,6 +1,6 @@
-import { desc, eq, inArray, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, or, sql, sum } from "drizzle-orm";
 import { db } from "./index";
-import { userRelationships, users } from "./schema";
+import { userRelationships, userRoomOverlaps, users } from "./schema";
 
 export interface RelationshipResult {
 	otherUserId: string;
@@ -26,6 +26,8 @@ export interface RelationshipWithUser extends RelationshipResult {
 export interface UserProfileData {
 	user: UserResult;
 	topRelationships: RelationshipWithUser[];
+	topRelationshipsLast30Days: RelationshipWithUser[];
+	stats: { totalWatchTime: number; watchTimeLast30Days: number };
 }
 
 /**
@@ -85,6 +87,72 @@ export async function getTopRelationships(
 	return relationships.map((rel: RelationshipResult) => ({
 		...rel,
 		user: otherUsers.find((u: UserResult) => u.id === rel.otherUserId),
+	}));
+}
+
+/**
+ * Get top users a specific user has shared room time with in the last 30 days
+ */
+export async function getTopRelationshipsLast30Days(
+	userId: string,
+	limit = 5,
+): Promise<RelationshipWithUser[]> {
+	const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+	const overlaps = await db
+		.select({
+			otherUserId: sql<string>`
+				CASE
+					WHEN ${userRoomOverlaps.user1Id} = ${userId} THEN ${userRoomOverlaps.user2Id}
+					ELSE ${userRoomOverlaps.user1Id}
+				END
+			`.as("other_user_id"),
+			totalTimeSeconds: sum(userRoomOverlaps.overlapSeconds).as(
+				"total_time_seconds",
+			),
+			roomsCount: sql<number>`count(distinct ${userRoomOverlaps.roomId})`.as(
+				"rooms_count",
+			),
+		})
+		.from(userRoomOverlaps)
+		.where(
+			and(
+				or(
+					eq(userRoomOverlaps.user1Id, userId),
+					eq(userRoomOverlaps.user2Id, userId),
+				),
+				gte(userRoomOverlaps.overlapStart, thirtyDaysAgo),
+			),
+		)
+		.groupBy(sql`1`)
+		.orderBy(desc(sum(userRoomOverlaps.overlapSeconds)))
+		.limit(limit);
+
+	const otherUserIds = overlaps.map((r) => r.otherUserId);
+
+	if (otherUserIds.length === 0) {
+		return [];
+	}
+
+	const otherUsers = await db
+		.select({
+			id: users.id,
+			name: users.name,
+			email: users.email,
+			image: users.image,
+			emailVerified: users.emailVerified,
+			createdAt: users.createdAt,
+			updatedAt: users.updatedAt,
+		})
+		.from(users)
+		.where(inArray(users.id, otherUserIds));
+
+	return overlaps.map((rel) => ({
+		otherUserId: rel.otherUserId,
+		totalTimeSeconds: Number(rel.totalTimeSeconds) || 0,
+		roomsCount: Number(rel.roomsCount) || 0,
+		lastInteractionAt: null,
+		user: otherUsers.find((u) => u.id === rel.otherUserId),
 	}));
 }
 

--- a/src/db/queries/community-stats.ts
+++ b/src/db/queries/community-stats.ts
@@ -29,11 +29,13 @@ async function calculateCommunityStats(): Promise<CommunityStats> {
 		.from(users);
 
 	// Watch hours this week (last 7 days)
-	// 1. Count completed sessions (users who left)
+	// 1. Count completed sessions that started this week
+	//    Filter by joinedAt (not leftAt) to avoid counting sessions that started
+	//    weeks ago but happened to end this week.
 	const completedWatchResult = await db
 		.select({ totalSeconds: sum(roomParticipants.totalTimeSeconds) })
 		.from(roomParticipants)
-		.where(gte(roomParticipants.leftAt, oneWeekAgo));
+		.where(gte(roomParticipants.joinedAt, oneWeekAgo));
 
 	// 2. Count ongoing sessions (users still in rooms who joined this week)
 	const ongoingWatchResult = await db

--- a/src/db/queries/stats.ts
+++ b/src/db/queries/stats.ts
@@ -39,6 +39,7 @@ function setCached<T>(key: string, data: T, ttl: number = CACHE_TTL): void {
 
 interface UserStats {
 	totalWatchTime: number;
+	watchTimeLast30Days: number;
 	totalRoomsJoined: number;
 	totalConnections: number;
 }
@@ -119,6 +120,17 @@ export async function getUserStats(userId: string): Promise<UserStats> {
 		.from(roomParticipants)
 		.where(eq(roomParticipants.userId, userId));
 
+	// Watch time in last 30 days
+	const watchTimeLast30DaysResult = await db
+		.select({ totalWatchTime: sum(roomParticipants.totalTimeSeconds) })
+		.from(roomParticipants)
+		.where(
+			and(
+				eq(roomParticipants.userId, userId),
+				gte(roomParticipants.joinedAt, thirtyDaysAgo),
+			),
+		);
+
 	// Total unique rooms joined
 	const roomsJoinedResult = await db
 		.select({ count: sql<number>`count(distinct ${roomParticipants.roomId})` })
@@ -138,6 +150,8 @@ export async function getUserStats(userId: string): Promise<UserStats> {
 
 	const stats = {
 		totalWatchTime: Number(watchTimeResult[0]?.totalWatchTime) || 0,
+		watchTimeLast30Days:
+			Number(watchTimeLast30DaysResult[0]?.totalWatchTime) || 0,
 		totalRoomsJoined: Number(roomsJoinedResult[0]?.count) || 0,
 		totalConnections: Number(connectionsResult[0]?.count) || 0,
 	};

--- a/src/db/queries/stats.ts
+++ b/src/db/queries/stats.ts
@@ -137,15 +137,12 @@ export async function getUserStats(userId: string): Promise<UserStats> {
 		.from(roomParticipants)
 		.where(eq(roomParticipants.userId, userId));
 
-	// Total connections (unique users met)
+	// Total connections (unique users met, all time)
 	const connectionsResult = await db
 		.select({ count: sql<number>`count(*)` })
 		.from(userRelationships)
 		.where(
-			and(
-				gte(userRelationships.lastInteractionAt, thirtyDaysAgo),
-				sql`(${userRelationships.user1Id} = ${userId} OR ${userRelationships.user2Id} = ${userId})`,
-			),
+			sql`(${userRelationships.user1Id} = ${userId} OR ${userRelationships.user2Id} = ${userId})`,
 		);
 
 	const stats = {

--- a/src/routes/profile.$userId.tsx
+++ b/src/routes/profile.$userId.tsx
@@ -89,22 +89,22 @@ function ProfilePage() {
 				</div>
 
 				<div className="bg-depth-1 rounded-lg p-6 border border-border-subtle">
-					<div className="grid grid-cols-3 gap-4 text-center">
+					<div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
 						<div>
 							<p className="text-text-tertiary text-sm">Member Since</p>
-							<p className="text-text-primary text-2xl font-bold mt-1">
+							<p className="text-text-primary text-xl font-bold mt-1">
 								{memberSince}
 							</p>
 						</div>
 						<div>
 							<p className="text-text-tertiary text-sm">Total Watch Time</p>
-							<p className="text-text-primary text-2xl font-bold mt-1">
+							<p className="text-text-primary text-xl font-bold mt-1">
 								{formatDuration(stats.totalWatchTime)}
 							</p>
 						</div>
 						<div>
 							<p className="text-text-tertiary text-sm">Last 30 Days</p>
-							<p className="text-text-primary text-2xl font-bold mt-1">
+							<p className="text-text-primary text-xl font-bold mt-1">
 								{formatDuration(stats.watchTimeLast30Days)}
 							</p>
 						</div>

--- a/src/routes/profile.$userId.tsx
+++ b/src/routes/profile.$userId.tsx
@@ -51,7 +51,11 @@ function ProfilePage() {
 		);
 	}
 
-	const { user, topRelationships } = profile;
+	const { user, topRelationships, topRelationshipsLast30Days, stats } = profile;
+	const memberSince = new Date(user.createdAt).toLocaleDateString("en-US", {
+		month: "short",
+		year: "numeric",
+	});
 
 	return (
 		<div className="h-full w-full bg-depth-0 px-4 py-12 overflow-auto">
@@ -80,14 +84,38 @@ function ProfilePage() {
 									</span>
 								)}
 							</h1>
-							<p className="text-text-secondary mt-1">{user.email}</p>
+						</div>
+					</div>
+				</div>
+
+				<div className="bg-depth-1 rounded-lg p-6 border border-border-subtle">
+					<div className="grid grid-cols-3 gap-4 text-center">
+						<div>
+							<p className="text-text-tertiary text-sm">Member Since</p>
+							<p className="text-text-primary text-2xl font-bold mt-1">
+								{memberSince}
+							</p>
+						</div>
+						<div>
+							<p className="text-text-tertiary text-sm">Total Watch Time</p>
+							<p className="text-text-primary text-2xl font-bold mt-1">
+								{formatDuration(stats.totalWatchTime)}
+							</p>
+						</div>
+						<div>
+							<p className="text-text-tertiary text-sm">Last 30 Days</p>
+							<p className="text-text-primary text-2xl font-bold mt-1">
+								{formatDuration(stats.watchTimeLast30Days)}
+							</p>
 						</div>
 					</div>
 				</div>
 
 				<div className="bg-depth-1 rounded-lg p-6 border border-border-subtle">
 					<h2 className="text-2xl font-bold text-text-primary mb-6">
-						{isOwnProfile ? "Your Top Connections" : "Top Connections"}
+						{isOwnProfile
+							? "Your Top Connections — All Time"
+							: "Top Connections — All Time"}
 					</h2>
 					{topRelationships.length === 0 ? (
 						<p className="text-text-secondary">
@@ -98,6 +126,65 @@ function ProfilePage() {
 					) : (
 						<div className="space-y-4">
 							{topRelationships.map((rel, index) => (
+								<Link
+									key={rel.otherUserId}
+									to="/profile/$userId"
+									params={{ userId: rel.otherUserId }}
+									className="flex items-center gap-4 p-4 bg-depth-2 rounded-lg hover:bg-depth-3 transition-colors"
+								>
+									<div className="shrink-0 w-8 h-8 rounded-full bg-accent/20 flex items-center justify-center">
+										<span className="text-sm font-bold text-accent">
+											#{index + 1}
+										</span>
+									</div>
+									{rel.user?.image ? (
+										<img
+											src={rel.user.image}
+											alt={rel.user.name}
+											className="h-12 w-12 rounded-full object-cover"
+										/>
+									) : (
+										<div className="h-12 w-12 rounded-full bg-surface-3 flex items-center justify-center">
+											<span className="text-lg font-medium text-text-primary">
+												{rel.user?.name?.charAt(0).toUpperCase() || "?"}
+											</span>
+										</div>
+									)}
+									<div className="flex-1 min-w-0">
+										<h3 className="text-lg font-semibold text-text-primary truncate">
+											{rel.user?.name || "Unknown User"}
+										</h3>
+										<p className="text-text-tertiary text-sm">
+											{rel.roomsCount} {rel.roomsCount === 1 ? "room" : "rooms"}
+										</p>
+									</div>
+									<div className="text-right">
+										<p className="text-lg font-bold text-accent">
+											{formatDuration(rel.totalTimeSeconds)}
+										</p>
+										<p className="text-text-tertiary text-sm">total time</p>
+									</div>
+								</Link>
+							))}
+						</div>
+					)}
+				</div>
+
+				<div className="bg-depth-1 rounded-lg p-6 border border-border-subtle">
+					<h2 className="text-2xl font-bold text-text-primary mb-6">
+						{isOwnProfile
+							? "Your Top Connections — Last 30 Days"
+							: "Top Connections — Last 30 Days"}
+					</h2>
+					{topRelationshipsLast30Days.length === 0 ? (
+						<p className="text-text-secondary">
+							{isOwnProfile
+								? "You haven't shared room time with anyone in the last 30 days."
+								: "This user hasn't shared room time with anyone in the last 30 days."}
+						</p>
+					) : (
+						<div className="space-y-4">
+							{topRelationshipsLast30Days.map((rel, index) => (
 								<Link
 									key={rel.otherUserId}
 									to="/profile/$userId"

--- a/src/routes/room.$roomId.tsx
+++ b/src/routes/room.$roomId.tsx
@@ -169,12 +169,15 @@ function RoomContent() {
 
 	const isActive = room.status === "active";
 	const isPreparing = room.status === "preparing";
+	const isEnded = room.status === "ended";
 
 	// Get streamer info from initial data (for SSR) or from roomState
 	const streamer = initialData?.room.streamer;
 
-	// Participants from roomState (real-time via WebSocket)
-	const participants = room.participants || [];
+	// Ended rooms use loader data (WebSocket never populates participants for ended rooms)
+	const participants = isEnded
+		? initialData?.participants || []
+		: room.participants || [];
 
 	// Leave room handler
 	const handleLeaveRoom = useCallback(() => {

--- a/src/routes/room.$roomId.tsx
+++ b/src/routes/room.$roomId.tsx
@@ -269,8 +269,12 @@ function RoomContent() {
 
 	const now = clientNow || new Date();
 	const startTime = room?.createdAt ? new Date(room.createdAt) : now;
+	const endTime =
+		isEnded && initialData?.room.room?.endedAt
+			? new Date(initialData.room.room.endedAt)
+			: now;
 	const totalDuration = Math.floor(
-		(now.getTime() - startTime.getTime()) / 1000,
+		(endTime.getTime() - startTime.getTime()) / 1000,
 	);
 
 	// Check if current user is a participant and if they're the streamer

--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -1,7 +1,12 @@
 import { createServerFn } from "@tanstack/react-start";
 import { eq } from "drizzle-orm";
 import { db } from "#/db/index";
-import { getTopRelationships, type UserProfileData } from "#/db/queries";
+import {
+	getTopRelationships,
+	getTopRelationshipsLast30Days,
+	type UserProfileData,
+} from "#/db/queries";
+import { getUserStats } from "#/db/queries/stats";
 import { users } from "#/db/schema";
 
 export const getProfileData = createServerFn({ method: "GET" })
@@ -25,10 +30,20 @@ export const getProfileData = createServerFn({ method: "GET" })
 			return null;
 		}
 
-		const topRelationships = await getTopRelationships(data.userId, 5);
+		const [topRelationships, topRelationshipsLast30Days, userStats] =
+			await Promise.all([
+				getTopRelationships(data.userId, 5),
+				getTopRelationshipsLast30Days(data.userId, 5),
+				getUserStats(data.userId),
+			]);
 
 		return {
 			user: user[0],
 			topRelationships,
+			topRelationshipsLast30Days,
+			stats: {
+				totalWatchTime: userStats.totalWatchTime,
+				watchTimeLast30Days: userStats.watchTimeLast30Days,
+			},
 		};
 	});


### PR DESCRIPTION
## Summary

- **Mobile layout**: Stack room layout vertically, add top bar, safe-area-inset support for notched phones, scope overflow correctly
- **Profile page**: Add stats card (Member Since, Total Watch Time, Last 30d) and Top Connections (Last 30d) card; remove publicly-visible email
- **Past streams**: Fix participant list and viewer count showing empty on ended room detail page; fix duration showing time-since-creation instead of actual stream duration
- **Stats accuracy**: Fix weekly watch time inflation (filter by joinedAt not leftAt), make totalConnections all-time, label Active Streamers as 30d window
- **Room list**: Correctly type RoomListProps, wire streamerIsPresent through to RoomCard
- **Drizzle**: Migration for community stats watch seconds column

## Test plan

- [ ] View site on mobile — room list stacks vertically, top bar visible, sidebar hidden
- [ ] View a past stream detail page — participants list populated, viewer count correct, duration shows actual stream length (not time since creation)
- [ ] View a user profile — stats card shows Member Since / Total Watch Time / Last 30 Days; email not shown; both All Time and Last 30 Days connections cards present; stats card stacks on mobile
- [ ] Check homepage sidebar — Watch Time (Week) reflects sessions started this week only; Connections shows all-time count; Active Streamers labelled (30d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)